### PR TITLE
Fix typo

### DIFF
--- a/org-pdfview.el
+++ b/org-pdfview.el
@@ -42,8 +42,8 @@
 
 (defun org-pdfview-store-link ()
   "Store a link to a pdfview buffer."
-  (when (eq major-mode 'pdfview-mode)
-    ;; This buffer is in pdfview-mode
+  (when (eq major-mode 'pdf-view-mode)
+    ;; This buffer is in pdf-view-mode
     (let* ((path buffer-file-name)
 	   (page (pdf-view-current-page))
 	   (link (concat "pdfview:" path "::" (number-to-string page)))


### PR DESCRIPTION
It's a typo in the mode name, isn't it?

(Also I think it should be 2015 in "Copyright (C) 2014 Markus Hauck" :-))
