### PR TITLE
Fix latex format

### DIFF
--- a/org-pdfview.el
+++ b/org-pdfview.el
@@ -79,7 +79,7 @@
       (setq path (org-link-escape (expand-file-name path)))
       (cond
        ((eq format 'html) (format "<a href=\"%s\">%s</a>" path desc))
-       ((eq format 'latex) (format "\href{%s}{%s}" path desc))
+       ((eq format 'latex) (format "\\href{%s}{%s}" path desc))
        ((eq format 'ascii) (format "%s (%s)" desc path))
        (t path)))))
 


### PR DESCRIPTION
Currently exports `href` but should be `\href`. Fix by escaping backslash
