### PR TITLE
Conditionally use new org (v. 9) api for link type

### DIFF
--- a/org-pdfview.el
+++ b/org-pdfview.el
@@ -36,8 +36,12 @@
 (require 'pdf-tools)
 (require 'pdf-view)
 
-(org-add-link-type "pdfview" 'org-pdfview-open 'org-pdfview-export)
-(add-hook 'org-store-link-functions 'org-pdfview-store-link)
+(if (fboundp 'org-link-set-parameters)
+    (org-link-set-parameters "pdfview"
+                             :follow #'org-pdfview-open
+                             :store #'org-pdfview-store-link)
+  (org-add-link-type "pdfview" 'org-pdfview-open)
+  (add-hook 'org-store-link-functions 'org-pdfview-store-link))
 
 (defun org-pdfview-open (link)
   "Open LINK in pdf-view-mode."


### PR DESCRIPTION
I'm using org-mode from master and with the new changes `org-store-link-functions` was removed so the correct store-function was not used at all. This uses the new api if `org-link-set-parameters` is defined.
